### PR TITLE
Add rotated_bbox_calibration

### DIFF
--- a/dotadevkit.py
+++ b/dotadevkit.py
@@ -1,0 +1,97 @@
+# please change CocoConvert.py to dotadevkit.py in your virtual environment
+
+# --------------------------------------------------------
+# Modified by Ashwin Nair
+# Written by Jian Ding for DOTA_Devkit
+# --------------------------------------------------------
+
+# common path: /anaconda3/envs/obbdetection/lib/python3.x/site-packages/dotadevkit/ops/CocoConvert.py
+
+import cv2
+import json
+
+from dotadevkit.misc.dota_utils import dota_classes, parse_dota_poly2
+from pathlib import Path
+
+
+def DOTA2COCO(srcpath, destfile, version="1.0"):
+    imageparent = srcpath / "images"
+    labelparent = srcpath / "labelTxt"
+    assert version in ["1.0", "1.5", "2.0"]
+
+    if version == "1.5":
+        dota_classes.append("container-crane")
+
+    if version == "2.0":
+        dota_classes.extend(["container-crane", "airport", "helipad"])
+
+    data_dict = {}
+    info = {
+        "contributor": "Captain Group, Wuhan University",
+        "data_created": "2018",
+        "description": f"DOTA dataset version {version}",
+        "url": "https://captain-whu.github.io/DOTA/dataset.html",
+        "version": version,
+        "year": 2018,
+    }
+    data_dict["info"] = info
+    data_dict["images"] = []
+    data_dict["categories"] = []
+    data_dict["annotations"] = []
+
+    for idex, name in enumerate(dota_classes):
+        single_cat = {"id": idex + 1, "name": name, "supercategory": name}
+        data_dict["categories"].append(single_cat)
+
+    inst_count = 1
+    image_id = 1
+    with open(destfile, "w") as f_out:
+        filenames = [lbl for lbl in labelparent.iterdir()]
+        for file in filenames:
+            basename = file.stem
+
+            imagepath = imageparent / (basename + ".png")
+            img = cv2.imread(str(imagepath))
+            if img is None:
+              print("can not load!")
+            else:
+              height, width, c = img.shape
+
+            single_image = {}
+            single_image["file_name"] = basename + ".png"
+            single_image["id"] = image_id
+            single_image["width"] = width
+            single_image["height"] = height
+            data_dict["images"].append(single_image)
+
+            # annotations
+            objects = parse_dota_poly2(file)
+            for obj in objects:
+                single_obj = {}
+                single_obj["area"] = obj["area"]
+                single_obj["category_id"] = dota_classes.index(obj["name"]) + 1
+                single_obj["segmentation"] = []
+                single_obj["segmentation"].append(obj["poly"])
+                single_obj["iscrowd"] = 0
+                x1, y1, x2, y2, x3, y3, x4, y4 = (obj["poly"][0], obj["poly"][1], obj["poly"][2], obj["poly"][3], obj["poly"][4], obj["poly"][5], obj["poly"][6], obj["poly"][7])
+                xmin, ymin, xmax, ymax = (
+                   min(obj["poly"][0::2]),
+                   min(obj["poly"][1::2]),
+                   max(obj["poly"][0::2]),
+                   max(obj["poly"][1::2]),
+                )
+
+                width, height = xmax - xmin, ymax - ymin
+                # single_obj["bbox"] = xmin, ymin, width, height
+                single_obj["bbox"] = x1, y1, x2, y2, x3, y3, x4, y4 # modify here
+                single_obj["image_id"] = image_id
+                data_dict["annotations"].append(single_obj)
+                single_obj["id"] = inst_count
+                inst_count = inst_count + 1
+            image_id = image_id + 1
+        json.dump(data_dict, f_out)
+
+
+if __name__ == "__main__":
+    out_dir = Path("home/ashwin/Desktop/Projects/dotadevkit/example_split")
+    DOTA2COCO(out_dir, out_dir / "DOTA_val.json", version="1.0")

--- a/tools/dota2coco_val_bbox.py
+++ b/tools/dota2coco_val_bbox.py
@@ -1,0 +1,50 @@
+import json
+import os
+import math
+
+
+class_map = ['plane', 'baseball-diamond', 'bridge', 'ground-track-field',
+         'small-vehicle', 'large-vehicle', 'ship', 'tennis-court',
+         'basketball-court', 'storage-tank', 'soccer-ball-field', 'roundabout',
+         'harbor', 'swimming-pool', 'helicopter']
+
+
+with open('/data/dota/val/DOTA_1.0.json', 'r') as file: # your path to the file
+    data = json.load(file)   
+image_id_mapping = {image['file_name'].split('.')[0]: image['id'] for image in data['images']}
+
+coco_format = []
+# your path to the directory containing the .txt files, which can be obtained from the mmrotate by using --format-only --eval-options
+# and here rmove "Task1_" in the .txt filename
+directory = '/data/val_results/rtmdet_results' 
+for file_name in os.listdir(directory):
+    if file_name.endswith('.txt'):
+        file_path = os.path.join(directory, file_name)
+        base_name = os.path.splitext(file_name)[0]
+        # print(file_path)
+        with open(file_path, 'r') as file:
+            # print(file)
+            for line in file:
+                parts = line.strip().split()
+                # print(parts[0])
+                image_id = image_id_mapping[parts[0]]
+                score = float(parts[1])
+                x1, y1, x2, y2, x3, y3, x4, y4 = map(float, parts[2:10])
+                xmin = min(x1, x2, x3, x4)
+                xmax = max(x1, x2, x3, x4)
+                ymin = min(y1, y2, y3, y4)
+                ymax = max(y1, y2, y3, y4)
+                width = xmax - xmin
+                height = ymax - ymin
+                coco_dict = {
+                    "image_id": int(image_id),
+                    "score": score,
+                    # "bbox": [xmin, ymin, width, height],
+                    "bbox": [x1, y1, x2, y2, x3, y3, x4, y4],
+                    "category_id": class_map.index(base_name) + 1
+                }
+                coco_format.append(coco_dict)
+           
+det_directory = 'mocae/calibration/rtmdet/obb_final_detections/val.bbox.json'  # your path to save the output json file  
+with open(det_directory, 'w') as output_file:
+    json.dump(coco_format, output_file)

--- a/tools/mocae_rotated_bounding_box.py
+++ b/tools/mocae_rotated_bounding_box.py
@@ -7,7 +7,7 @@ import argparse
 import ast
 
 def obtain_moe_for_rotated(calibrate, iou_thr):
-    model_names = ['rotated_rtmdet', 'lsk']
+    model_names = ['rtmdet', 'lsk']
     from_scratch = True
     det_paths = []
     

--- a/tools/train_calibrator.py
+++ b/tools/train_calibrator.py
@@ -20,7 +20,7 @@ from mmdet.utils import (build_ddp, build_dp, compat_cfg, get_device,
                          replace_cfg_vals, setup_multi_processes,
                          update_data_root)
 
-from analysis_tools.model_calibration import nn_calibrator
+from tools.analysis_tools.model_calibration_rotate import nn_calibrator
 
 def parse_args():
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
First, you can obtain a DOTA_1.0.json file in coco-style after modifying the CocoConvert.py in dotadevkit, as written in tools/dotadevkit.py, some thing like this: {'image_id': 25, 'score': 0.97, 'bbox': [385.79, 1783.79, 407.02, 1137.92, 89.9, 1127.49, 68.66, 1773.36], 'category_id': 4}.
Then, you should use tools/dota2coco_val_bbox.py to get coco-style detection results on valid set.
Finally, you can get a calibrator using tools/analysis_tools/model_calibration_rotate.py in which I modified the bbox_overlaps() to box_iou_quadri() to compute rotated bounding box ious. 
I got the same calibrator provided in the zip file and reproduce the results in Table 9.
Please modify the file path first when calibrating your own object detectors!